### PR TITLE
M-4 Setup continuous integration

### DIFF
--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -2,11 +2,11 @@ name: Java CI with Maven
 
 on:
   push:
-    branches:
-    - '!main'
+    branches-ignore:
+    - main
   pull_request:
-    branches:
-    - '!main'
+    branches-ignore:
+    - main
 
 jobs:
   build:
@@ -21,9 +21,9 @@ jobs:
         java-version: '11'
         distribution: 'temurin'
         cache: maven
-    
+
     - name: Build with Maven
       run: mvn -B package --file pom.xml
-    
+
     - name: Run tests with Maven
       run: mvn test


### PR DESCRIPTION
Change ci-config to work as intended (run github action 'Java CI with Maven' after each pull request, excluding main branch)